### PR TITLE
fix: add trailing slash to sync command path

### DIFF
--- a/.devops/pagopa-deploy-pipelines.yml
+++ b/.devops/pagopa-deploy-pipelines.yml
@@ -110,7 +110,7 @@ stages:
               azureSubscription: 'DEV-PAGOPA-SERVICE-CONN'
               scriptLocation: inlineScript
               inlineScript: |
-                az storage blob sync --container '$web' --account-name pagopadcheckoutsa -s '$(Pipeline.Workspace)/Bundle_DEV' -d 'ecommerce-fe'
+                az storage blob sync --container '$web' --account-name pagopadcheckoutsa -s '$(Pipeline.Workspace)/Bundle_DEV' -d 'ecommerce-fe/'
 
           - task: AzureCLI@1
             displayName: 'Purge CDN endpoint on DEV'
@@ -241,7 +241,7 @@ stages:
               azureSubscription: 'UAT-PAGOPA-SERVICE-CONN'
               scriptLocation: inlineScript
               inlineScript: |
-                az storage blob sync --container '$web' --account-name pagopaucheckoutsa -s '$(Pipeline.Workspace)/Bundle_UAT' -d 'ecommerce-fe'
+                az storage blob sync --container '$web' --account-name pagopaucheckoutsa -s '$(Pipeline.Workspace)/Bundle_UAT' -d 'ecommerce-fe/'
 
           - task: AzureCLI@1
             displayName: 'Purge CDN endpoint on UAT'
@@ -333,7 +333,7 @@ stages:
               azureSubscription: 'PROD-PAGOPA-SERVICE-CONN'
               scriptLocation: inlineScript
               inlineScript: |
-                az storage blob sync --container '$web' --account-name pagopapcheckoutsa -s '$(Pipeline.Workspace)/Bundle_PROD' -d 'ecommerce-fe'
+                az storage blob sync --container '$web' --account-name pagopapcheckoutsa -s '$(Pipeline.Workspace)/Bundle_PROD' -d 'ecommerce-fe/'
 
           - task: AzureCLI@1
             displayName: 'Purge CDN endpoint on PROD'


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add missing trailing slash to sync command
<!--- Describe your changes in detail -->

#### Motivation and Context
Old file were not deleted during sync operation due to missing slash in file to delete path with error:
```
INFO: Deleting extra object: favicon-32x32.731222b9.png
INFO: error DELETE https://pagopadcheckoutsa.blob.core.windows.net/$web/ecommerce-fefavicon-32x32.731222b9.png
--------------------------------------------------------------------------------
RESPONSE 404: 404 The specified blob does not exist.
ERROR CODE: BlobNotFound

```
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Deploy in DEV environment 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
