### PR TITLE
fix: [MAIN-3] set session storage if not present for checkout polling

### DIFF
--- a/src/routes/PaymentResponsePage.tsx
+++ b/src/routes/PaymentResponsePage.tsx
@@ -13,7 +13,11 @@ import {
 } from "../utils/api/transactions/types";
 import PageContainer from "../components/PageContainer";
 import { getOnboardingPaymentOutcome } from "../utils/api/transactions/TransactionResultUtil";
-import { SessionItems, getSessionItem } from "../utils/storage/sessionStorage";
+import {
+  SessionItems,
+  getSessionItem,
+  setSessionItemIfNotPresent,
+} from "../utils/storage/sessionStorage";
 import { getFragments, redirectToClient } from "../utils/urlUtilities";
 import { getConfigOrThrow } from "../utils/config/config";
 import { CLIENT_TYPE, ROUTE_FRAGMENT } from "./models/routeModel";
@@ -51,6 +55,9 @@ export default function PaymentResponsePage() {
 
   const GetTransaction = (token: string) => {
     const manageResp = O.match(redirectWithError, (transactionInfo) => {
+      if (clientId === CLIENT_TYPE.CHECKOUT) {
+        setSessionItemIfNotPresent(SessionItems.transaction, transactionInfo);
+      }
       performRedirectToClient(
         getOnboardingPaymentOutcome(transactionInfo as transactionInfoStatus)
       );

--- a/src/utils/storage/sessionStorage.ts
+++ b/src/utils/storage/sessionStorage.ts
@@ -2,6 +2,7 @@ import { NewTransactionResponse } from "../../../generated/definitions/payment-e
 
 export enum SessionItems {
   sessionToken = "sessionToken",
+  transaction = "transaction",
 }
 
 export const getSessionItem = (item: SessionItems) => {
@@ -26,6 +27,18 @@ export function setSessionItem(
     name,
     typeof item === "string" ? item : JSON.stringify(item)
   );
+}
+
+export function setSessionItemIfNotPresent(
+  name: SessionItems,
+  item: string | NewTransactionResponse
+) {
+  if (!sessionStorage.getItem(name)) {
+    sessionStorage.setItem(
+      name,
+      typeof item === "string" ? item : JSON.stringify(item)
+    );
+  }
 }
 
 export const clearStorage = () => {


### PR DESCRIPTION
Set transaction attribute to session storage when come back from checkout APM payment flow

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
