### PR TITLE
fix: [CHK-4360] Fixed counter reset when refreshing after polling ends.

### DIFF
--- a/src/utils/api/client.ts
+++ b/src/utils/api/client.ts
@@ -27,7 +27,6 @@ export const decodeFinalStatusResult = async (
 ): Promise<boolean> => {
   pollingConfig.counter.increment();
   if (pollingConfig.counter.getValue() === pollingConfig.retries) {
-    pollingConfig.counter.reset();
     return false;
   }
   const { isFinalStatus } = (await r.clone().json()) as TransactionOutcomeInfo;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Prevented the counter from resetting when the page is refreshed after polling has ended.

#### Motivation and Context

Previously, refreshing the page after polling completion would reset the counter, unintentionally triggering a new polling cycle.
This fix ensures that once polling has finished, refreshing the page does not restart it, preserving the intended end state.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
