### PR TITLE
feat: [PIDM-1435] Reset polling counter before touchpoint redirect

### DIFF
--- a/src/routes/PaymentResponsePage.tsx
+++ b/src/routes/PaymentResponsePage.tsx
@@ -47,6 +47,7 @@ export default function PaymentResponsePage() {
     totalAmount?: AmountEuroCents,
     fees?: AmountEuroCents
   ) => {
+    pollingConfig.counter.reset();
     // if not present new outcome use old one
     const outcome = newOutcome || outcomeState || ViewOutcomeEnum.GENERIC_ERROR;
     redirectToClient({ transactionId, outcome, clientId, totalAmount, fees });

--- a/src/routes/__tests__/PaymentResponsePage.test.tsx
+++ b/src/routes/__tests__/PaymentResponsePage.test.tsx
@@ -115,6 +115,7 @@ describe("PaymentResponsePage", () => {
       transactionId: "tx1",
       outcome: ViewOutcomeEnum.GENERIC_ERROR,
     });
+    expect(pollingConfig.counter.reset).toHaveBeenCalled();
   });
 
   it("on SUCCESS shows continue button only after the delay (IO)", async () => {
@@ -149,6 +150,7 @@ describe("PaymentResponsePage", () => {
     expect(document.getElementById("continueToIOBtn")).toBeInTheDocument();
 
     jest.useRealTimers();
+    expect(pollingConfig.counter.reset).toHaveBeenCalled();
   });
 
   it("calls CHECKOUT-get + redirects to GENERIC_ERROR when API yields none (CHECKOUT)", async () => {
@@ -172,6 +174,7 @@ describe("PaymentResponsePage", () => {
       transactionId: "txC1",
       outcome: ViewOutcomeEnum.GENERIC_ERROR,
     });
+    expect(pollingConfig.counter.reset).toHaveBeenCalled();
   });
 
   it("calls CHECKOUT-get + redirects to SUCCESS when API yields some (CHECKOUT)", async () => {
@@ -208,5 +211,6 @@ describe("PaymentResponsePage", () => {
     expect(document.getElementById("continueToIOBtn")).toBeNull();
 
     jest.useRealTimers();
+    expect(pollingConfig.counter.reset).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Reset counter polling in session storage before final redirect

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
[PIDM-1435](https://pagopa.atlassian.net/browse/PIDM-1435)
Prevent counter to be increased with a subsequent payment after the first one

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


[PIDM-1435]: https://pagopa.atlassian.net/browse/PIDM-1435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ