### PR TITLE
remove classic cdn options from deploy pipeline

### DIFF
--- a/.devops/azure-templates/setup-env.yml
+++ b/.devops/azure-templates/setup-env.yml
@@ -49,13 +49,6 @@ parameters:
   
   - name: 'io_client_save_card_fail_redirect'
     type: string
-  
-  - name: 'use_ecommerce_fe_root_path'
-    type: boolean
-    default: false
-    values:
-      - false
-      - true
 
 
     
@@ -77,7 +70,6 @@ steps:
       ECOMMERCE_SHOW_CONTINUE_IO_BTN_DELAY_MILLIS=${{ parameters.show_continue_io_btn_delay_millis }} \
       ECOMMERCE_IO_CARD_DATA_CLIENT_REDIRECT_OUTCOME_PATH=${{parameters.io_client_redirect_card_data_outcome_path }} \
       ECOMMERCE_IO_SAVE_CARD_FAIL_REDIRECT_PATH=${{parameters.io_client_save_card_fail_redirect}} \
-      USE_ECOMMERCE_FE_ROOT_PATH=${{lower(parameters.use_ecommerce_fe_root_path)}} \
       bash env.sh
 
   displayName: 'Populate environment file'

--- a/.devops/pagopa-deploy-pipelines.yml
+++ b/.devops/pagopa-deploy-pipelines.yml
@@ -23,34 +23,17 @@ parameters:
       - minor
       - patch
     default: minor
-  - name: 'USE_ECOMMERCE_CDN'
-    displayName: 'Boolean parameter used to indicate if use eCommerce CDN (if false Checkout one will be used)'
-    type: boolean
-    default: true
-    values:
-      - false
-      - true
 
 
 variables:
   NODE_VERSION: 18.17.1
   YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
-  ${{ if eq(parameters['USE_ECOMMERCE_CDN'], true) }}:
-      DEV_STORAGE_BLOB_SYNC: az storage blob sync --container '$web' --account-name pagopadweuecommercecdnsa -s '$(Pipeline.Workspace)/Bundle_DEV'
-      DEV_PURGE_CDN_COMMAND: az afd endpoint purge -g pagopa-d-ecommerce-fe-rg --endpoint-name pagopa-d-weu-ecommerce-cdn-endpoint --profile-name pagopa-d-weu-ecommerce-cdn-profile --domains dev.ecommerce.pagopa.it --content-paths "/*"
-      UAT_STORAGE_BLOB_SYNC: az storage blob sync --container '$web' --account-name pagopauweuecommercecdnsa -s '$(Pipeline.Workspace)/Bundle_UAT'
-      UAT_PURGE_CDN_COMMAND: az afd endpoint purge -g pagopa-u-ecommerce-fe-rg --endpoint-name pagopa-u-weu-ecommerce-cdn-endpoint --profile-name pagopa-u-weu-ecommerce-cdn-profile --domains uat.ecommerce.pagopa.it --content-paths "/*"
-      PROD_STORAGE_BLOB_SYNC: az storage blob sync --container '$web' --account-name pagopapweuecommercecdnsa -s '$(Pipeline.Workspace)/Bundle_PROD'
-      PROD_PURGE_CDN_COMMAND: az afd endpoint purge -g pagopa-p-ecommerce-fe-rg --endpoint-name pagopa-p-weu-ecommerce-cdn-endpoint --profile-name pagopa-p-weu-ecommerce-cdn-profile --domains ecommerce.pagopa.it --content-paths "/*"
-      USE_ECOMMERCE_FE_ROOT_PATH: "false"
-  ${{ else }}:
-      DEV_STORAGE_BLOB_SYNC: az storage blob sync --container '$web' --account-name pagopadcheckoutsa -s '$(Pipeline.Workspace)/Bundle_DEV' -d 'ecommerce-fe/'
-      DEV_PURGE_CDN_COMMAND: az cdn endpoint purge -g pagopa-d-checkout-fe-rg -n pagopa-d-checkout-cdn-endpoint --profile-name pagopa-d-checkout-cdn-profile --content-paths "/*"
-      UAT_STORAGE_BLOB_SYNC: az storage blob sync --container '$web' --account-name pagopaucheckoutsa -s '$(Pipeline.Workspace)/Bundle_UAT' -d 'ecommerce-fe/'
-      UAT_PURGE_CDN_COMMAND: az cdn endpoint purge -g pagopa-u-checkout-fe-rg -n pagopa-u-checkout-cdn-endpoint --profile-name pagopa-u-checkout-cdn-profile --content-paths "/*"
-      PROD_STORAGE_BLOB_SYNC: az storage blob sync --container '$web' --account-name pagopapcheckoutsa -s '$(Pipeline.Workspace)/Bundle_PROD' -d 'ecommerce-fe/'
-      PROD_PURGE_CDN_COMMAND: az cdn endpoint purge -g pagopa-p-checkout-fe-rg -n pagopa-p-checkout-cdn-endpoint --profile-name pagopa-p-checkout-cdn-profile --content-paths "/*"
-      USE_ECOMMERCE_FE_ROOT_PATH: "true"
+  DEV_STORAGE_BLOB_SYNC: az storage blob sync --container '$web' --account-name pagopadweuecommercecdnsa -s '$(Pipeline.Workspace)/Bundle_DEV'
+  DEV_PURGE_CDN_COMMAND: az afd endpoint purge -g pagopa-d-ecommerce-fe-rg --endpoint-name pagopa-d-weu-ecommerce-cdn-endpoint --profile-name pagopa-d-weu-ecommerce-cdn-profile --content-paths "/*"
+  UAT_STORAGE_BLOB_SYNC: az storage blob sync --container '$web' --account-name pagopauweuecommercecdnsa -s '$(Pipeline.Workspace)/Bundle_UAT'
+  UAT_PURGE_CDN_COMMAND: az afd endpoint purge -g pagopa-u-ecommerce-fe-rg --endpoint-name pagopa-u-weu-ecommerce-cdn-endpoint --profile-name pagopa-u-weu-ecommerce-cdn-profile --content-paths "/*"
+  PROD_STORAGE_BLOB_SYNC: az storage blob sync --container '$web' --account-name pagopapweuecommercecdnsa -s '$(Pipeline.Workspace)/Bundle_PROD'
+  PROD_PURGE_CDN_COMMAND: az afd endpoint purge -g pagopa-p-ecommerce-fe-rg --endpoint-name pagopa-p-weu-ecommerce-cdn-endpoint --profile-name pagopa-p-weu-ecommerce-cdn-profile --content-paths "/*"
 
 # Only manual activations are intended
 trigger: none
@@ -111,17 +94,10 @@ stages:
               show_continue_io_btn_delay_millis: 2000
               io_client_redirect_card_data_outcome_path: 'https://api.dev.platform.pagopa.it/ecommerce/io-outcomes/v1/payments/cards/outcomes'
               io_client_save_card_fail_redirect: 'https://api.dev.platform.pagopa.it/payment-wallet-outcomes/v1/wallets/contextual-onboard/outcomes'
-              use_ecommerce_fe_root_path: ${{variables.USE_ECOMMERCE_FE_ROOT_PATH}}
 
           - script: |
               yarn build
             displayName: 'Build with `/` root path'
-            condition: eq(${{parameters.USE_ECOMMERCE_CDN}}, true)
-
-          - script: |
-              yarn build:ecommerce-fe-root
-            displayName: 'Build with `/ecommerce-fe` root path'
-            condition: eq(${{parameters.USE_ECOMMERCE_CDN}}, false)
             
           - publish: $(System.DefaultWorkingDirectory)/dist
             artifact: Bundle_DEV
@@ -239,17 +215,10 @@ stages:
               show_continue_io_btn_delay_millis: 2000
               io_client_redirect_card_data_outcome_path: 'https://api.uat.platform.pagopa.it/ecommerce/io-outcomes/v1/payments/cards/outcomes'
               io_client_save_card_fail_redirect: 'https://api.uat.platform.pagopa.it/payment-wallet-outcomes/v1/wallets/contextual-onboard/outcomes'
-              use_ecommerce_fe_root_path: ${{variables.USE_ECOMMERCE_FE_ROOT_PATH}}
 
           - script: |
               yarn build
             displayName: 'Build with `/` root path'
-            condition: eq(${{parameters.USE_ECOMMERCE_CDN}}, true)
-
-          - script: |
-              yarn build:ecommerce-fe-root
-            displayName: 'Build with `/ecommerce-fe` root path'
-            condition: eq(${{parameters.USE_ECOMMERCE_CDN}}, false)
 
           - publish: $(System.DefaultWorkingDirectory)/dist
             artifact: Bundle_UAT
@@ -342,17 +311,10 @@ stages:
               show_continue_io_btn_delay_millis: 2000
               io_client_redirect_card_data_outcome_path: 'https://api.platform.pagopa.it/ecommerce/io-outcomes/v1/payments/cards/outcomes'
               io_client_save_card_fail_redirect: 'https://api.platform.pagopa.it/payment-wallet-outcomes/v1/wallets/contextual-onboard/outcomes'
-              use_ecommerce_fe_root_path: ${{variables.USE_ECOMMERCE_FE_ROOT_PATH}}
 
           - script: |
               yarn build
             displayName: 'Build with `/` root path'
-            condition: eq(${{parameters.USE_ECOMMERCE_CDN}}, true)
-
-          - script: |
-              yarn build:ecommerce-fe-root
-            displayName: 'Build with `/ecommerce-fe` root path'
-            condition: eq(${{parameters.USE_ECOMMERCE_CDN}}, false)
 
           - publish: $(System.DefaultWorkingDirectory)/dist
             artifact: Bundle_PROD

--- a/.env.development
+++ b/.env.development
@@ -14,4 +14,3 @@ ECOMMERCE_SHOW_CONTINUE_IO_BTN_DELAY_MILLIS=2000
 ECOMMERCE_API_RETRY_NUMBERS_LINEAR=2
 ECOMMERCE_IO_CARD_DATA_CLIENT_REDIRECT_OUTCOME_PATH=iowallet://card-data-outcome-url
 ECOMMERCE_IO_SAVE_CARD_FAIL_REDIRECT_PATH=https://api.dev.platform.pagopa.it/payment-wallet-outcomes/v1/wallets/contextual-onboard/outcomes
-USE_ECOMMERCE_FE_ROOT_PATH=false

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ The ecommerce transaction get transaction endpoint `/checkout/webview/v1/transac
 | Variable name                       | Description                                                   | type   | default |
 |-------------------------------------|---------------------------------------------------------------|--------|---------|
 | ECOMMERCE_API_RETRY_NUMBERS_LINEAR  | number of calls at regular intervals                          | number | 5       |
-| USE_ECOMMERCE_FE_ROOT_PATH.         | boolean parameter to include ecommerce-fe as root path or no  | boolean | false  |
 
 ## Polling
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
     "lint": "eslint . -c .eslintrc.js --ext .ts,.tsx",
     "lint-autofix": "eslint . -c .eslintrc.js --ext .ts,.tsx --fix",
     "prebuild": "npm-run-all generate type-check lint",
-    "prebuild:ecommerce-fe-root": "npm-run-all generate type-check lint",
-    "build:ecommerce-fe-root": "rimraf .cache && rimraf dist && parcel build src/index.html --public-url /ecommerce-fe && cp -R static/* dist/",
     "build": "rimraf .cache && rimraf dist && parcel build src/index.html && cp -R static/* dist/",
     "dev": "rimraf .cache && rimraf dist && npm-run-all generate type-check dev:env dev:server",
     "proxy": "npm-run-all generate type-check dev:env dev:proxy",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,6 @@ import { EcommerceRoutes } from "./routes/models/routeModel";
 import PaymentResponsePage from "./routes/PaymentResponsePage";
 import GdiCheckPage from "./routes/GdiCheckPage";
 import "./translations/i18n";
-import { getConfigOrThrow } from "./utils/config/config";
 
 const checkoutTheme = createTheme({
   ...theme,
@@ -42,8 +41,6 @@ const checkoutTheme = createTheme({
   },
 });
 
-const useEcommerceRootPath = getConfigOrThrow().USE_ECOMMERCE_FE_ROOT_PATH;
-
 export function App() {
   const { t } = useTranslation();
   // eslint-disable-next-line functional/immutable-data
@@ -58,7 +55,7 @@ export function App() {
         }}
       >
         <Routes>
-          <Route path={useEcommerceRootPath ? EcommerceRoutes.ROOT : "/"}>
+          <Route path="/">
             <Route path="" element={<Navigate to={EcommerceRoutes.ESITO} />} />
             <Route
               path={EcommerceRoutes.GDI_CHECK}

--- a/src/utils/__tests__/urlUtilities.test.ts
+++ b/src/utils/__tests__/urlUtilities.test.ts
@@ -8,14 +8,6 @@ jest.mock("../../routes/models/routeModel", () => ({
   },
 }));
 
-const mockConfig = {
-  USE_ECOMMERCE_FE_ROOT_PATH: true,
-};
-
-jest.mock("../../utils/config/config", () => ({
-  getConfigOrThrow: () => mockConfig,
-}));
-
 const originalLocation = window.location;
 const mockLocation: Partial<Location> = {
   search: "",
@@ -213,26 +205,13 @@ describe("redirectToClient", () => {
 });
 
 describe("getRootPath", () => {
-  it.each([
-    {
-      paramValue: true,
-      expectedRootPath: "/ecommerce-fe/",
-    },
-    {
-      paramValue: false,
-      expectedRootPath: "/",
-    },
-  ])(
-    "should return root path valued accordingly to parameter: [%s]",
-    ({ paramValue, expectedRootPath }) => {
-      // reset modules to change parameter value
-      jest.resetModules();
-      // eslint-disable-next-line functional/immutable-data
-      mockConfig.USE_ECOMMERCE_FE_ROOT_PATH = paramValue;
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const reloadedUrlUtilities = require("../urlUtilities");
-      // and then perform test against the reloaded module with updated parameter value
-      expect(reloadedUrlUtilities.getRootPath()).toEqual(expectedRootPath);
-    }
-  );
+  it("should return root path '/' ", () => {
+    // reset modules to change parameter value
+    jest.resetModules();
+    // eslint-disable-next-line functional/immutable-data
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const reloadedUrlUtilities = require("../urlUtilities");
+    // and then perform test against the reloaded module with updated parameter value
+    expect(reloadedUrlUtilities.getRootPath()).toEqual("/");
+  });
 });

--- a/src/utils/config/config.ts
+++ b/src/utils/config/config.ts
@@ -29,7 +29,6 @@ export const IConfig = t.interface({
   ECOMMERCE_API_RETRY_NUMBERS_LINEAR: t.number,
   ECOMMERCE_IO_CARD_DATA_CLIENT_REDIRECT_OUTCOME_PATH: NonEmptyString,
   ECOMMERCE_IO_SAVE_CARD_FAIL_REDIRECT_PATH: NonEmptyString,
-  USE_ECOMMERCE_FE_ROOT_PATH: t.boolean,
 });
 
 // No need to re-evaluate this object for each call
@@ -95,12 +94,6 @@ const errorOrConfig: t.Validation<IConfig> = IConfig.decode({
     ? // eslint-disable-next-line no-underscore-dangle
       (window as any)._env_.ECOMMERCE_IO_SAVE_CARD_FAIL_REDIRECT_PATH
     : null,
-  // eslint-disable-next-line no-underscore-dangle
-  USE_ECOMMERCE_FE_ROOT_PATH: (window as any)._env_
-    .ECOMMERCE_IO_SAVE_CARD_FAIL_REDIRECT_PATH
-    ? // eslint-disable-next-line no-underscore-dangle
-      (window as any)._env_.USE_ECOMMERCE_FE_ROOT_PATH === "true"
-    : false,
 });
 
 /**

--- a/src/utils/urlUtilities.ts
+++ b/src/utils/urlUtilities.ts
@@ -6,14 +6,9 @@ import {
   CHECKOUT_CLIENT_REDIRECT_OUTCOME_PATH,
   ROUTE_FRAGMENT,
   CLIENT_TYPE,
-  EcommerceRoutes,
 } from "../routes/models/routeModel";
 import { ViewOutcomeEnum } from "./api/transactions/types";
-import { getConfigOrThrow } from "./config/config";
 import { getSessionItem, SessionItems } from "./storage/sessionStorage";
-
-export const useEcommerceRootPath =
-  getConfigOrThrow().USE_ECOMMERCE_FE_ROOT_PATH;
 
 export function getUrlParameter(name: string) {
   const myname = name.replace(/[[]/, "\\[").replace(/[\]]/, "\\]");
@@ -165,5 +160,4 @@ export interface WalletContextualOnboardOutcomeParams {
   faultCodeDetail?: string;
 }
 
-export const getRootPath = (): string =>
-  useEcommerceRootPath ? `/${EcommerceRoutes.ROOT}/` : `/`;
+export const getRootPath = (): string => `/`;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Removed the `USE_ECOMMERCE_CDN` pipeline parameter and the related conditional logic.
- Simplified the Azure DevOps deployment pipeline so that DEV, UAT, and PROD always deploy to the dedicated eCommerce CDN/storage accounts.
- Removed the `USE_ECOMMERCE_FE_ROOT_PATH` environment variable from:
  - Azure environment setup template
  - `.env.development`
  - runtime configuration validation
  - README documentation
- Updated the application routing so the app is always mounted from `/.`
- Simplified `getRootPath()` so it always returns `/.`
- Updated the related unit test expectations for getRootPath().
- Removed the obsolete `build:ecommerce-fe-root` and `prebuild:ecommerce-fe-root` scripts from `package.json`
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
